### PR TITLE
Allow larger Post body.

### DIFF
--- a/lib/generators/forum_monster/templates/migrations/posts.rb
+++ b/lib/generators/forum_monster/templates/migrations/posts.rb
@@ -1,7 +1,7 @@
 class CreatePostsTable < ActiveRecord::Migration
   def self.up
     create_table :posts, :force => true do |t|
-      t.string   :body
+      t.text     :body
       t.integer  :forum_id
       t.integer  :topic_id
       t.integer  :user_id


### PR DESCRIPTION
Large posts worked fine for me locally, where I was using SQLite. When I pushed my app to Heroku (and PostgreSQL), the large posts caused a database exception -- too large for string.

Some string vs. text background: http://stackoverflow.com/questions/3354330/difference-between-string-and-text-in-rails
