### PR TITLE
Basic formatting & links

### DIFF
--- a/lib/generators/forum_monster/templates/views/topics/show.html.erb
+++ b/lib/generators/forum_monster/templates/views/topics/show.html.erb
@@ -33,7 +33,7 @@
       </tr>
       <tr>
         <td class="post_body">
-          <%= post.body %>
+          <%= simple_format(post.body) %>
         </td>
       </tr>
       <% end %>

--- a/lib/generators/forum_monster/templates/views/topics/show.html.erb
+++ b/lib/generators/forum_monster/templates/views/topics/show.html.erb
@@ -33,7 +33,7 @@
       </tr>
       <tr>
         <td class="post_body">
-          <%= simple_format(post.body) %>
+          <%= simple_format(auto_link(post.body)) %>
         </td>
       </tr>
       <% end %>


### PR DESCRIPTION
Thanks again for Forum Monster. Here are two changes I've implemented in my own app. You might want them in the base -- but given the strong philosophy of the project, maybe not. No problem either way.

Using simple_format is really useful. The first time my users carefully formatted their post and saw all the line breaks go away, I Got Mail! I also sleep a little better knowing it sanitizes malicious code.
- http://api.rubyonrails.org/classes/ActionView/Helpers/TextHelper.html#method-i-simple_format

My users also requested auto_link. This might not fit with Forum Monster philosophy. First, it's changing the text, not just preserving it as simple_format does. Also, the #auto_link method was removed in Rails 3.1 and moved to a gem, rails_autolink.
- http://apidock.com/rails/ActionView/Helpers/TextHelper/auto_link
- https://rubygems.org/gems/rails_autolink

If these changes don't belong in the base code, I'd be happy to document them in a wiki page if that's appropriate.
